### PR TITLE
Fix unrendered LaTeX, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ Manifest.toml
 .ipynb_checkpoints
 *.ipynb
 todo
+
+# Documentation
+docs/build/
+# Mac temporaries
+*.DS_Store
+# package logo
+!docs/src/assets/*.png
+# vim swap files
+*.swp
+

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,8 +16,14 @@ makedocs(
     ],
     #format = Documenter.HTML(assets = ["assets/custom.css"])
     format = Documenter.HTML(
-        prettyurls = get(ENV, "CI", nothing) == "true"
-    )
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        mathengine = MathJax(Dict(
+            :TeX => Dict(
+                :equationNumbers => Dict(:autoNumber => "AMS"),
+                :Macros => Dict()
+            )
+        ))
+    ),
     #assets = ["assets/custom.css"],
     #strict = true
 )


### PR DESCRIPTION
 - Adds some file extensions and docs/build directory, [as suggested](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#.gitignore-1), to .gitignore
 - Adds MathJax to docs `format` to fix [un-rendered LaTeX](https://jdeldre.github.io/ViscousFlow.jl/latest/manual/fields/#Fields-1)