### PR TITLE
Copied f vector into tmp before making saddle point solution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ColorTypes = "^0"
+ColorTypes = ">=0.10.2"
 Dierckx = "^0"
 DiffRules = ">=0"
 DocStringExtensions = "^0"

--- a/src/SaddlePointSystems.jl
+++ b/src/SaddlePointSystems.jl
@@ -162,9 +162,9 @@ function ldiv!(state::Tuple{TU,TF},
   ru, rf = rhs
   u, f = state
   sys.B₂A⁻¹r₁ .= sys.B₂A⁻¹(ru)
-  rf .-= sys.B₂A⁻¹r₁
+  sys.tmpvec .= rf
+  sys.tmpvec .-= sys.B₂A⁻¹r₁
   if N > 0
-    sys.tmpvec .= rf
     sys.tmpvecout .= f
     cg!(sys.tmpvecout,sys.S,sys.tmpvec,tol=sys.tol)
     f .= sys.tmpvecout
@@ -184,9 +184,9 @@ function ldiv!(state::Tuple{TU,TF},
   ru, rf = rhs
   u, f = state
   sys.B₂A⁻¹r₁ .= sys.B₂A⁻¹(ru)
-  rf .-= sys.B₂A⁻¹r₁
+  sys.tmpvec .= rf
+  sys.tmpvec .-= sys.B₂A⁻¹r₁
   if N > 0
-    sys.tmpvec .= rf
     ldiv!(sys.S⁻¹,sys.tmpvec)
     f .= sys.tmpvec
     f .= sys.P(f)


### PR DESCRIPTION
In the `ldiv!` operations in the saddle-point solver, copies the constraint part of the right-hand side into a temporary variable to avoid mutating it.

Fixes #12 